### PR TITLE
Don't run checkInteractNearby on every tick (#1443)

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1758,7 +1758,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         }
 
         this.checkTeleportPosition();
-        this.checkInteractNearby();
+        
+        if (currentTick % 10 == 0) {
+            this.checkInteractNearby();
+        }
 
         if (this.spawned && this.dummyBossBars.size() > 0 && currentTick % 100 == 0) {
             this.dummyBossBars.values().forEach(DummyBossBar::updateBossEntityPosition);


### PR DESCRIPTION
Whatever this method is required for (something with vehicle interaction on mobile I guess) it surely doesn't have to run on every tick. Because of the usage of `getEntityPlayerLookingAt` not running this on every tick will improve the server performance especially when there are many players online. I didn't find any side effects from this change.